### PR TITLE
chore: add `exports`  to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "router",
     "react-router"
   ],
+	"exports": {
+		"import": "./dist/index.mjs",
+		"require": "./dist/index.js",
+		"types": "./dist/index.d.ts"
+	},
   "files": [
     "dist"
   ],


### PR DESCRIPTION
**Description**:
Vite@5 don't support `cjs` file, so add `exports` to package.json so that vite can load es module file